### PR TITLE
Update README.md to correct repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The exploit only prints `PPPwned` on your PS4 as a proof-of-concept. In order to
 On your computer, clone the repository:
 
 ```sh
-git clone --recursive https://github.com/TheOfficialFloW/PPPwn
+git clone --recursive https://github.com/LightningMods/PPPwn
 ```
 
 Change the directory to the cloned repository:


### PR DESCRIPTION
I am re-submitting this PR (old #2) as @LightningMods did not make the change him/herself after me closing the old one (by mistake).

The URL at the `On your computer, clone the repository:` part is pointing to TheOfficialFlow's repository. This could be misleading.