### PR TITLE
Add `permanent_uart`.

### DIFF
--- a/permanent_uart/Makefile
+++ b/permanent_uart/Makefile
@@ -1,0 +1,37 @@
+LIBPS4	:= $(PS4SDK)/libPS4
+
+CC	:= gcc
+OBJCOPY	:= objcopy
+ODIR	:= build
+SDIR	:= source
+IDIRS	:= -I$(LIBPS4)/include -Iinclude
+LDIRS	:= -L$(LIBPS4)
+MAPFILE := $(shell basename "$(CURDIR)").map
+CFLAGS	:= $(IDIRS) -Os -std=c11 -ffunction-sections -fdata-sections -fno-builtin -nostartfiles -nostdlib -Wall -Wextra -masm=intel -march=btver2 -mtune=btver2 -m64 -mabi=sysv -mcmodel=small -fpie -fPIC
+LFLAGS	:= $(LDIRS) -Xlinker -T $(LIBPS4)/linker.x -Xlinker -Map="$(MAPFILE)" -Wl,--build-id=none -Wl,--gc-sections
+CFILES	:= $(wildcard $(SDIR)/*.c)
+SFILES	:= $(wildcard $(SDIR)/*.s)
+OBJS	:= $(patsubst $(SDIR)/%.c, $(ODIR)/%.o, $(CFILES)) $(patsubst $(SDIR)/%.s, $(ODIR)/%.o, $(SFILES))
+
+LIBS	:= -lPS4
+
+TARGET = $(shell basename "$(CURDIR)").bin
+
+$(TARGET): $(ODIR) $(OBJS)
+	$(CC) $(LIBPS4)/crt0.s $(ODIR)/*.o -o temp.t $(CFLAGS) $(LFLAGS) $(LIBS)
+	$(OBJCOPY) -O binary temp.t "$(TARGET)"
+	rm -f temp.t
+
+$(ODIR)/%.o: $(SDIR)/%.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(ODIR)/%.o: $(SDIR)/%.s
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(ODIR):
+	@mkdir $@
+
+.PHONY: clean
+
+clean:
+	rm -rf "$(TARGET)" "$(MAPFILE)" $(ODIR)

--- a/permanent_uart/source/main.c
+++ b/permanent_uart/source/main.c
@@ -1,0 +1,90 @@
+#include <ps4.h>
+
+// #define DEBUG_SOCKET
+// #define DEBUG_IP "192.168.1.200"
+// #define DEBUG_PORT 9023
+
+static int (*sceKernelDebugOutText)(int,
+                                    const char *) = NULL;
+// size_t page_size = 0x4000;
+
+void *kernel_base = NULL;
+int kpayload(struct thread *td) {
+  kernel_base = &((uint8_t *)__readmsr(0xC0000082))[-0x1C0];
+
+  struct ucred *cred = td->td_proc->p_ucred;
+  cred->cr_uid = 0;
+  cred->cr_ruid = 0;
+  cred->cr_rgid = 0;
+  cred->cr_groups[0] = 0;
+
+  // escalate ucred privs, needed for access to the filesystem ie* mounting & decrypting files
+  void *td_ucred = *(void **)(((char *)td) + 304); // p_ucred == td_ucred
+
+  // sceSblACMgrIsSystemUcred
+  uint64_t *sonyCred = (uint64_t *)(((char *)td_ucred) + 96);
+  *sonyCred = 0xffffffffffffffff;
+
+  // sceSblACMgrGetDeviceAccessType
+  uint64_t *sceProcType = (uint64_t *)(((char *)td_ucred) + 88);
+  *sceProcType = 0x3801000000000013; // Max access
+
+  // sceSblACMgrHasSceProcessCapability
+  uint64_t *sceProcCap = (uint64_t *)(((char *)td_ucred) + 104);
+  *sceProcCap = 0xffffffffffffffff; // Sce Process
+
+  return 0;
+}
+
+int _main(struct thread *td) {
+  UNUSED(td);
+
+  // Initialize PS4 Kernel, libc, and networking
+  initKernel();
+  initLibc();
+  initSysUtil();
+
+  // Load and resolve libkernel_sys library
+  int libk = sceKernelLoadStartModule("libkernel_sys.sprx", 0, NULL, 0, 0, 0);
+  RESOLVE(libk, sceKernelDebugOutText);
+
+  sceKernelSleep(1);
+
+  // Output initialization messages
+  if (sceKernelDebugOutText) {
+    sceKernelDebugOutText(0, "==========================\n");
+    sceKernelDebugOutText(0, "Hello From inside Shellcore!!!\n");
+    sceKernelDebugOutText(0, "==========================\n");
+  }
+
+#ifdef DEBUG_SOCKET
+  initNetwork();
+  DEBUG_SOCK = SckConnect(DEBUG_IP, DEBUG_PORT);
+#endif
+
+  // jailbreak();
+  syscall(11, &kpayload, NULL);
+
+  printf_notification("kbase: %p, waiting 5 secs", kernel_base);
+  sceKernelSleep(5);
+
+  // sceKernelDebugOutText(0, "called enable_perm_uart()\n");
+  // enable_perm_uart();
+
+  uint64_t (*icc_nvs_write)(uint32_t block, uint32_t offset, uint32_t size, void *value);
+
+  icc_nvs_write = (void *)(kernel_base + K1100_ICC_NVS_WRITE);
+
+  sceKernelDebugOutText(0, "called icc_nvs_write()\n");
+  char uart = 1;
+  icc_nvs_write(4, 0x31F, 1, &uart);
+
+  printf_notification("Enabled UART!");
+
+#ifdef DEBUG_SOCKET
+  printf_debug("Closing socket...\n");
+  SckClose(DEBUG_SOCK);
+#endif
+
+  return 0;
+}

--- a/permanent_uart/source/main.c
+++ b/permanent_uart/source/main.c
@@ -33,6 +33,13 @@ int kpayload(struct thread *td) {
   uint64_t *sceProcCap = (uint64_t *)(((char *)td_ucred) + 104);
   *sceProcCap = 0xffffffffffffffff; // Sce Process
 
+  uint64_t (*icc_nvs_write)(uint32_t block, uint32_t offset, uint32_t size, void *value);
+
+  icc_nvs_write = (void *)(kernel_base + K1100_ICC_NVS_WRITE);
+
+  char uart = 1;
+  icc_nvs_write(4, 0x31F, 1, &uart);
+
   return 0;
 }
 
@@ -65,19 +72,8 @@ int _main(struct thread *td) {
   // jailbreak();
   syscall(11, &kpayload, NULL);
 
-  printf_notification("kbase: %p, waiting 5 secs", kernel_base);
-  sceKernelSleep(5);
-
   // sceKernelDebugOutText(0, "called enable_perm_uart()\n");
   // enable_perm_uart();
-
-  uint64_t (*icc_nvs_write)(uint32_t block, uint32_t offset, uint32_t size, void *value);
-
-  icc_nvs_write = (void *)(kernel_base + K1100_ICC_NVS_WRITE);
-
-  sceKernelDebugOutText(0, "called icc_nvs_write()\n");
-  char uart = 1;
-  icc_nvs_write(4, 0x31F, 1, &uart);
 
   printf_notification("Enabled UART!");
 


### PR DESCRIPTION
**Help needed**

I've checked offset `K1100_ICC_NVS_WRITE` with a couple kernel dumps (from different consoles) and its correct.

Executing `enable_permanent_uart()` logs:

```
pppoe0: lcp TO(req-sent) rst_counter = 9

*** network error happened: 0x80411413 ***
pppoe0: lcp TO(ack-sent) rst_counter = 10
pppoe0: ipcp TO(ack-sent) rst_counter = 10
ifa_del_loopback_route: deletion failed
**********************************   stage2                                            
Patching vm_map_protect, ptrace, ASLR and kmem_alloc                                   
kexec added                                                                            
payload_size: 7820                                                                     
Finding SceShellCore process...                                                        
Found SceShellCore process @ PID 41
Allocated payload memory @ 0x0000000926200000
Writing payload...
proc_rw_mem: uio.uio_resid: 7820
Wrote payload!
Creating ShellCore payload thread...
proc_create_thread starting .........
vm_map_findspace: 0, 0x4000
vm_map_insert: 0 0x4000
rpcldraddr: 0x4000
vm_map_findspace: 0, 0x8000
vm_map_insert: 0 0x8000
stackaddr: 0x8000
proc_rw_mem: uio.uio_resid: 255
rpcldr written
thr: 0xffffd0c92cbb4000
zvm_map_lookup_entry
done
entries->start: 0x4000, entries->offset 0, num_entries 893
libkernel_sys.sprx found
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 1
proc_create_thread done .........
Created payload thread!

*** network ready. myaddr: 42.42.42.42 ***
[SceRnpsAppMgr] network available
[SceRnpsAppMgr] Enqueued : m_trigger = 4
[ScePatchChecker] Patch Check Request (type=0 trigger=3)
[SceRnpsAppMgr] Finish m_trigger=4
==========================
Hello From inside Shellcore!!!
==========================
[NOTIFICATION]: kbase: ffffffffcfc64000, waiting 5 secs
called enable_perm_uart()


Fatal trap 9: general protection fault while in kernel mode
ICC 07-01 polling
ICC 07-00 polling
ICC 02-0b polling
mDBG: Mute audio.
mDBG: Mute audio done.
mDBG: Power down...
mDBG: ...
ICC 04-01 nowait

```

But unrolling the function results on a different error:

```
pppoe0: lcp TO(req-sent) rst_counter = 9

*** network error happened: 0x80411413 ***
pppoe0: lcp TO(ack-sent) rst_counter = 10
pppoe0: ipcp TO(ack-sent) rst_counter = 10
ifa_del_loopback_route: deletion failed
**********************************   stage2                                            
Patching vm_map_protect, ptrace, ASLR and kmem_alloc                                   
kexec added                                                                            
payload_size: 7820                                                                     
Finding SceShellCore process...                                                        
Found SceShellCore process @ PID 41
Allocated payload memory @ 0x0000000926200000
Writing payload...
proc_rw_mem: uio.uio_resid: 7820
Wrote payload!
Creating ShellCore payload thread...
proc_create_thread starting .........
vm_map_findspace: 0, 0x4000
vm_map_insert: 0 0x4000
rpcldraddr: 0x4000
vm_map_findspace: 0, 0x8000
vm_map_insert: 0 0x8000
stackaddr: 0x8000
proc_rw_mem: uio.uio_resid: 255
                                                                                                                                             7
pppoe0: lcp TO(req-sent) rst_counter = 9

*** network error happened: 0x80411413 ***
pppoe0: lcp TO(ack-sent) rst_counter = 10
pppoe0: ipcp TO(ack-sent) rst_counter = 10
ifa_del_loopback_route: deletion failed
**********************************   stage2
Patching vm_map_protect, ptrace, ASLR and kmem_alloc
kexec added
payload_size: 5404
Finding SceShellCore process...
Found SceShellCore process @ PID 42
Allocated payload memory @ 0x0000000926200000
Writing payload...
proc_rw_mem: uio.uio_resid: 5404
Wrote payload!
Creating ShellCore payload thread...
proc_create_thread starting .........
vm_map_findspace: 0, 0x4000
vm_map_insert: 0 0x4000
rpcldraddr: 0x4000
vm_map_findspace: 0, 0x8000
vm_map_insert: 0 0x8000
stackaddr: 0x8000
proc_rw_mem: uio.uio_resid: 255
rpcldr written
thr: 0xffff8e1730b190b0
zvm_map_lookup_entry
done
entries->start: 0x4000, entries->offset 0, num_entries 893
libkernel_sys.sprx found
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 8
proc_rw_mem: uio.uio_resid: 1
proc_create_thread done .........
Created payload thread!

*** network ready. myaddr: 42.42.42.42 ***
[SceRnpsAppMgr] network available
[SceRnpsAppMgr] Enqueued : m_trigger = 4
[ScePatchChecker] Patch Check Request (type=0 trigger=3)
[SceRnpsAppMgr] Finish m_trigger=4
==========================
Hello From inside Shellcore!!!
==========================
[NOTIFICATION]: kbase: ffffffff84548000, waiting 5 secs
[SceShellCore] VM Stats: RSS 551.3, kernel 268.7, wire count 332.2, swap out 0.0, page table CPU 2480/6144 GPU 385/2048
[SceShellCore] FMEM   1.3/   4.5 NPXS20977 SceSysAvControl.elf
[SceShellCore] FMEM  10.6/  74.3 NPXS20991 SceSysCore.elf
[SceShellCore] FMEM   9.3/  54.3 NPXS20973 orbis_audiod.elf
[SceShellCore] FMEM   3.2/  11.2 NPXS20976 GnmCompositor.elf
[SceShellCore] FMEM  38.0/ 351.0 NPXS20000 SceShellCore
[SceShellCore] FMEM 343.9/ 837.3 NPXS20001 SceShellUI
[SceShellCore] FMEM   3.4/   8.3 NPXS21003 SceAvCapture
[SceShellCore] FMEM   8.1/  32.4 NPXS21000 SceGameLiveStreaming
[SceShellCore] FMEM  13.9/  50.4 NPXS21002 ScePartyDaemon
[SceShellCore] FMEM   4.2/  25.4 NPXS21004 SceVideoCoreServer
[SceShellCore] FMEM  11.3/  49.2 NPXS21006 SceRemotePlay
[SceShellCore] FMEM   6.7/  19.5 NPXS21010 SceCloudClientDaemon
[SceShellCore] FMEM   3.3/  11.0 NPXS21016 SceSpZeroConf
[SceShellCore] FMEM   6.3/  18.1 NPXS21019 SceSocialScreenMgr
[SceShellCore] FMEM   8.1/ 156.3 NPXS21002 webrtc_daemon.self
[SceShellCore] FMEM   4.3/   9.8 NPXS21007 SceMusicCoreServer
[SceShellCore] FMEM   6.4/  14.3 NPXS21020 SceVoiceAndAgent
[SceShellCore] FMEM   2.0/   5.1 NPXS20967 fs_cleaner.elf
[SceShellCore] FMEM   2.0/  10.2 NPXS20974 SceVdecProxy.elf
[SceShellCore] FMEM   2.0/  10.3 NPXS20975 SceVencProxy.elf
[SceShellCore] FMEM  22.0/ 263.7 NPXS20001 SecureUIProcess.self
[SceShellCore] FMEM  30.5/ 525.8 NPXS20001 SecureWebProcess.self
[SceShellCore] FMEM  10.4/ 358.8 NPXS20001 orbis-jsc-compiler.self
called icc_nvs_write()
[Syscore App] App Crash : PID=0x2a, reason=0xb
[Syscore App] coredumpHandlingThreadEntry()[503] : SCE_SYSCORE_EVENT_APP_CRASH (0x2a, 0x60000100, 0x10100010)
[Syscore App] AppCrash : AppId=0x60000100, localPid=0x10100010, pid=0x2a
[Syscore App]            isDebuggable=0, enableCrashReport=0x1, reason=0xb
[Syscore App]            isKeepProcess()=0, sceKernelCheckDipsw(SCE_KERNEL_DIPSW_LIMIT_KEEP_PROCESS)=0
[Syscore App] createCoredumpOfApp()[294] : kick coredump : /user/data/sce_coredumps/NPXS20000_1715090928//NPXS20000_1715090928.sorbisdmp
[coredump] start: /user/data/sce_coredumps/NPXS20000_1715090928//NPXS20000_1715090928.sorbisdmp
[Syscore App] Coredump Progress : PID=0x2a, 0 %
[Syscore App] Coredump Progress : PID=0x2a, 5 %
[Syscore App] Coredump Progress : PID=0x2a, 10 %
[Syscore App] Coredump Progress : PID=0x2a, 15 %
[Syscore App] Coredump Progress : PID=0x2a, 20 %
[Syscore App] Coredump Progress : PID=0x2a, 25 %
[Syscore App] Coredump Progress : PID=0x2a, 30 %
[Syscore App] Coredump Progress : PID=0x2a, 35 %
[Syscore App] Coredump Progress : PID=0x2a, 40 %
[Syscore App] Coredump Progress : PID=0x2a, 45 %
[Syscore App] Coredump Progress : PID=0x2a, 50 %
[Syscore App] Coredump Progress : PID=0x2a, 55 %
[Syscore App] Coredump Progress : PID=0x2a, 60 %
[Syscore App] Coredump Progress : PID=0x2a, 65 %
[Syscore App] Coredump Progress : PID=0x2a, 70 %
[Syscore App] Coredump Progress : PID=0x2a, 75 %
[Syscore App] Coredump Progress : PID=0x2a, 80 %
[Syscore App] Coredump Progress : PID=0x2a, 85 %
[Syscore App] Coredump Progress : PID=0x2a, 90 %
[Syscore App] Coredump Progress : PID=0x2a, 95 %
[coredump] end  : 0x00000000
[Syscore App] Coredump Complete : PID=0x2a, exitStatus=0
[Syscore App] createCoredumpOfApp()[312] : coredump handling finish
[Syscore App] Kill App : 0x60000100 NPXS20000
[Syscore App] Kill process: 0x2a
[mbus] onSessionKilled. pid=42
@ removeSession:L184
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x2a
[Syscore App] Kill process: 0x2a => 0
[AppMgr Trace]: pid=0x2a, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON#_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000100  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[Syscore App] blockingKill(0x60000100, 1) complete
[AppMgr] checkAppTerminated invalid app.
[Syscore App] process delete event : pid=0x2a
[Syscore App] AppMgr is killing all app
[Syscore App] Kill App : 0x60000201 NPXS20001
[Syscore App] Kill process: 0x3a
 GPU Protection fault. vmid: system process3,pid: 0x28, client: TC0, access: Read
# reason: Unmapped page access, Protection fault addr(VA): 0x00000011809a7000
# Raw fault info: 0x06117002  Timestamp:26830585030
# GPU Protection fault. vmid: system process3,pid: 0x28, client: TC0, access: Read
# reason: Unmapped page access, Protection fault a[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x3a
[Syscore App] Kill process: 0x3a => 0
[AppMgr Trace]: pid=0x3a, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[Syscore App] Kill process: 0x3b
ddr(VA): 0x00000011809a7000
# Raw fault info: 0x06117002  Timestamp:26838907720
[Syscore App] process delete event : pid=0x3a
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x3c
[Syscore Umd] W:\Build\J02650690\sys\internal\syscore\u#md\umd_manager.cpp(1090) error : 0x80020003
[Syscore App] Kill process: 0x3b => 0x80020003
[Syscore App] process delete event : pid=0x3c
[AppMgr Trace]: pid=0x3b, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[Syscore App] Kill process: 0x3c
[Syscore Umd] W:\Build\J02650690\sys\internal\syscore\umd\umd_manager.cpp(1090) error : 0x80020003
[Syscore App] Kill process: 0x3c => 0x80020003
[AppMgr Trace]: pid=0x3c, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[Syscore App] Kill process: 0x2b
 GPU Protection fault. vmid: system process3,pid: 0x28, client: TC0, access: Read
# reason: Unmapped page access, Protection fault addr(VA): 0x00000011809a7000
# Raw fault info: 0x06117002  Timestamp:26845542295
[KE]sceCameraDevKill::2685 ERROR: sceCameraProcConfigStop 0x802e0006 i=0 handle=257 pid=43
[mbus] onSessionKilled. pid=43
@ removeSession:L184
Context.cc:174 (ajmContextCleanup) - Instance 16389 was not properly destroyed.
Context.cc:189 (ajmContextCleanup) - Codec MP3 Decoder was not properly unregistered.
Context.cc:189 (ajmContextCleanup) - Codec ATRAC9 Decoder was not properly unregistered.
[Syscore App] Kill process: 0x2b => 0
[AppMgr Trace]: pid=0x2b, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_OCN_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000201  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000302 NPXS21003
[Syscore App] Kill process: 0x2c
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x3b
[mbus] onSessionKilled. pid=44
@ removeSession:L184
ontext.cc:189 (ajmContextCleanup) - Codec MPEG4 AAC Encoder was not properly unregistered.
[Syscore App] Kill process: 0x2c => 0
[Syscore App] process delete event : pid=0x3b
[Syscore App] EVFCILT_PROC NOTE_EXIT received : pid=0x2b
[Syscore App] process delete event : pid=0x2b
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x2c
[Syscore App] process delete event : pid=0x2c
[AppMgr Trace]: pid=0x2c, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000302  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000403 NPXS21000
[Syscore App] Kill process: 0x2d
[mbus] onSessionKilled. pid=45
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x2d
[Syscore App] Kill process: 0x2d => 0
@ removeSession:L184
[Syscore App] process delete event : pid=0x2d
[AppMgr Trace]: pid=0x2d, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000403  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000504 NPXS21002
[Syscore App] Kill process: 0x34
ontext.cc:189 (ajmContextCleanup) - Codec Opus SILK Encoder was not properly unregistered.
Context.cc:189 (ajmContextCleanup) - Codec Opus CELT Encoder was not properly unregistered.
Context.cc:189 (ajmContextCleanup) - Codec Opus Decoder was not properly unregistered.
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x34
[SyscorCe App] Kill process: 0x34 => 0
[Syscore App] process delete event : pid=0x34
[AppMgr Trace]: pid=0x34, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[Syscore App] Kill process: 0x2e
[mbus] onSessionKilled. pid=46
@ removeSession:L184
ontext.cc:189 (ajmContextCleanup) - Codec CELP8 Decoder was not properly unregistered.
Context.cc:189 (ajmContextCleanup) - Codec CELP8 Encoder was not properly unregistered.
Context.cc:189 (ajmContextCleanup) - Codec CELP(16) Decoder was not properly unregistered.
Context.cc:191 (ajmContextCleanup) - More codecs were not properly unregistered...
[Syscore App] Kill process: 0x2e => 0
[AppMgr Trace]: pid=0x2e, deleted.
[Syscore AppC] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000504  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000605 NPXS21004
[Syscore App] Kill process: 0x2f
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x2e
[mbus] onSessionKilled. pid=47
@ removeSession:L184
[Syscore App] Kill process: 0x2f => 0
[Syscore App] process delete event : pid=0x2e
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x2f
[Syscore App] process delete event : pid=0x2f
[AppMgr Trace]: pid=0x2f, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000605  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000706 NPXS21006
[Syscore App] Kill process: 0x30
[mbus] onSessionKilled. pid=48
@ removeSession:L184
ontext.cc:189 (ajmContextCleanup) - Codec Opus CELT Encoder was not properly unregistered.
Context.cc:189 (ajmContextCleanup) - Codec Opus CELT Decoder was not properly unregistered.
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x30
[Syscore App] Kill process: 0x30 => 0
[Syscore App] process delete event : pid=0x30
[CAppMgr Trace]: pid=0x30, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000706  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000807 NPXS21010
[Syscore App] Kill process: 0x31
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x31
[Syscore App] Kill process: 0x31 => 0
[Syscore App] process delete event : pid=0x31
[AppMgr Trace]: pid=0x31, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000807  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000908 NPXS21016
[Syscore App] Kill process: 0x32
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x32
[Syscore App] Kill process: 0x32 => 0
[Syscore App] process delete event : pid=0x32
[AppMgr Trace]: pid=0x32, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000908  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000a09 NPXS21019
[Syscore App] Kill process: 0x33
[mbus] onSessionKilled. pid=51
@ removeSession:L184
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x33
[Syscore App] Kill process: 0x33 => 0
[Syscore App] process delete event : pid=0x33
[AppMgr Trace]: pid=0x33, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000a09  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000b0a NPXS21007
[Syscore App] Kill process: 0x35
[mbus] onSessionKilled. pid=53
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x35
@ removeSession:L184
[Syscore App] Kill process: 0x35 => 0
[Syscore App] process delete event : pid=0x35
[AppMgr Trace]: pid=0x35, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000b0a  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] Kill App : 0x60000c0b NPXS21020
[Syscore App] Kill process: 0x36
[mbus] onSessionKilled. pid=54
@ removeSession:L184
ontext.cc:174 (ajmContextCleanup) - Instance 278532 was not properly destroyed.
Context.cc:189 (ajmContextCleanup) - Codec Opus SILK Encoder was not properly unregistered.
Context.cc:174 (ajmContextCleanup) - Instance 344067 was not properly destroyed.
Context.cc:189 (ajmContextCleanup) - Codec Opus Decoder was not properly unregistered.
[Syscore App] EVFILT_PROC NOTE_EXIT received : pid=0x36
[Syscore App] Kill process: 0x36 => 0
[Syscore App] process delete eveCnt : pid=0x36
[AppMgr Trace]: pid=0x36, deleted.
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_PROCESS_UNLOADED
[AppMgr] All processes exited
[Syscore App] Syscore Event Queue Push : SCE_SYSCORE_EVENT_ON_APP_UNLOADED
[AppMgr Trace]: AppId=0x60000c0b  deleted
[Syscore App] Kill App : 0xffffffff  => 0
[AppMgr] checkAppTerminated invalid app.
[Syscore App] ShellCore exited, System Shutdown
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=4 start
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=4 end
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=3 start
[Syscore Umd] send event SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), pid=0xffffffff, phase=3 to /system/sys/orbis_audiod.elf
[Syscore Umd] received reply from /system/sys/orbis_audiod.elf (0.31 msec)
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=3 end
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=2 start
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=2 end
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=1 start
[Syscore Umd] Calling umd callback eventid=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), pid=0xffffffff, phase=1
[Syscore Umd] callback finished (0.00 msec)
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=1 end
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=0 start
[Syscore Umd] Event id=SCE_UMD_SYSTEM_EVENT_REBOOT(0x6), phase=0 end
[Syscore Umd] m_backupRestoreMode=0
[DTL] Closed.
[Syscore App] sceUmdReboot(0x4000) => 0
[Syscore App]  ExpandCpuSetMode : enable
ontext.cc:174 (ajmContextCleanup) - Instance 114689 was not properly destroyed.
Context.cc:189 (ajmContextCleanup) - Codec AC3 Encoder was not properly unregistered.
Context.cc:174 (ajmContextCleanup) - Instance 163842 was not properly destroyed.
Context.cc:189 (ajmContextCleanup) - Codec DTS Encoder was not properly unregistered.
[SceSysCore mini] killall timeout 5[sec]...
[SceSysCore mini] forcibly unmount 6 nullfses
[SceSysCore mini] forcibly unmount /mnt/usb0
[SceSysCore mini] forcibly unmount /mnt/usb1
[SceSysCore mini] sceKernelPollEventFlag(reboot_[REGMGR] 000006 ...
flag): failed 80020010
[SceSysCore mini] call r[eboot(4000)
REGMGR] (    276.980 sec) 010006 ...
[REGMGR] (   0.008778 sec) 010007 ...
[REGMGR] 000108 ...
[REGMGR] 000501 ...
Waiting (max 60 seconds) for system process `SceVnlru' to stop...done
Waiting (max 60 seconds) for system process `SceBufdaemon2' to stop...done
Waiting (max 60 seconds) for system process `SceSyncer' to stop...
Syncing disks, vnodes remaining...2 0 0 sched_sync: flush softdep (iter=2)
sched_sync: flush softdep (iter=1)
done
Waiting (max 60 seconds) for system process `SceBufdaemon0' to stop...done
Waiting (max 60 seconds) for system process `SceBufdaemon1' to stop...done
All buffers synced.
Uptime: 4m42s
icc post sync:Thermal alert LED off
[REGMGR] 000007 @2@ ...
icc08-4001 0802
icc:failed to disabled reset button notification: 0005
icc:disabled thermal notification
ICC: howto:00004000 depth:2 cause:00 hand:01
ICC: Shutdown.
ICC 04-01 nowait

```

Maybe something needs to be patched before executing `icc_nvs_write()`?