### PR TITLE
add -fpic and -fpie to both stages for gcc versions that don't enable it by default

### DIFF
--- a/stage1/Makefile
+++ b/stage1/Makefile
@@ -3,7 +3,7 @@ OBJS = start.o stage1.o
 
 CC = gcc
 OBJCOPY = objcopy
-CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector
+CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector -fpic -fpie
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
 ifneq ($(filter $(FW), 850 900 903 904 950 960 1000 1001 1050 1070 1071 1100),)

--- a/stage2/Makefile
+++ b/stage2/Makefile
@@ -3,7 +3,7 @@ OBJS = start.o stage2.o proc_utils.o  utils.o
 
 CC = gcc
 OBJCOPY = objcopy
-CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector 
+CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector -fpic -fpie
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
 ifdef ENABLE_DEBUG_MENU_OFF


### PR DESCRIPTION
I added the same to upstream but you didn't merge it